### PR TITLE
fix the issue of animation listener is null

### DIFF
--- a/lib/widgets/AnimationBuilder.dart
+++ b/lib/widgets/AnimationBuilder.dart
@@ -292,8 +292,14 @@ class AnimationBuilderState extends State<AnimationBuilder> with TickerProviderS
 
   @override
   void dispose() {
-    _animation!.removeListener(_listener!);
-    _animation!.removeStatusListener(_statusListener!);
+    if (_listener != null) {
+      _animation!.removeListener(_listener!);
+    }
+
+    if (_statusListener != null) {
+      _animation!.removeStatusListener(_statusListener!);
+    }
+
     controller!.dispose();
     super.dispose();
   }


### PR DESCRIPTION
Signed-off-by: lijun <260108593@qq.com>

In dispose, if the listener is null, an error to happen.
